### PR TITLE
Improve refresh feature

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -135,7 +135,7 @@ func TestCreateDocument(t *testing.T) {
 				Index:   indexName,
 				ID:      body.Id,
 				Body:    body,
-				Refresh: RefreshTrue,
+				Refresh: RefreshFalse,
 			})
 			assert.NoError(t, err)
 			assert.Equal(t, StatusCreated, status)
@@ -150,7 +150,7 @@ func TestCreateDocument(t *testing.T) {
 				Index:   indexName,
 				ID:      body.Id,
 				Body:    body,
-				Refresh: RefreshTrue,
+				Refresh: RefreshWaitFor,
 			})
 			assert.NoError(t, err)
 			assert.Equal(t, StatusCreated, status)


### PR DESCRIPTION
### DONE
- Add refresh option to `CreateDocument` request
- Allow refresh specific indices instead of all


### Ref

- https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-refresh.html
- https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-refresh.html