### PR TITLE
e["error"]の二ルポエラーを修正

### DIFF
--- a/main.go
+++ b/main.go
@@ -475,12 +475,25 @@ func search(client *goElasticsearch.Client, index string, query string) (StatusC
 		if err := json.NewDecoder(res.Body).Decode(&e); err != nil {
 			esErr = fmt.Errorf("error parsing the response body: %s", err)
 		} else {
-			//Print the response status and error information.
-			esErr = fmt.Errorf("[%s] %s: %s",
-				res.Status(),
-				e["error"].(map[string]any)["type"],
-				e["error"].(map[string]any)["reason"],
-			)
+			errorType := "unknown"
+			errorReason := "unknown"
+
+			if errData, ok := e["error"]; ok && errData != nil {
+				if errMap, ok := errData.(map[string]any); ok {
+					if t, ok := errMap["type"].(string); ok {
+						errorType = t
+					}
+					if r, ok := errMap["reason"].(string); ok {
+						errorReason = r
+					}
+				} else if errStr, ok := errData.(string); ok {
+					errorReason = errStr
+				}
+			} else {
+				errorReason = "response body does not contain error field"
+			}
+
+			esErr = fmt.Errorf("[%s] %s: %s", res.Status(), errorType, errorReason)
 		}
 		log.Println(esErr)
 


### PR DESCRIPTION
type, reasonを型安全に取り出す対応。

調べてもわからなかったんですが、es clientのversion upなどでres.Bodyの値が変わったことで発生するようになったかもしれないです。

https://ap-northeast-1.console.aws.amazon.com/cloudwatch/home?region=ap-northeast-1#logsV2:log-groups/log-group/%2Faws%2Flambda%2Fpro-media-api-core-TeamFileAggregateFunction-C8xFhMUlYfxl/log-events/2025%2F12%2F07%2F%5B$LATEST%5D89f9fbdc61744bb98df30888c632a9a9?start=2025-12-07T08:29:16.031Z&refEventId=39362959626553182858697659905166790411719985723835875371